### PR TITLE
docs: create PROJECT.md and slim down CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,188 +1,90 @@
-# Claude Code Instructions for Tone of Voice App
+# Claude Code Instructions
 
-This file contains durable instructions for Claude Code when working on this codebase.
+This file contains durable working instructions for Claude Code on this codebase.
+For product details, architecture, and flows see **`PROJECT.md`**.
 
 ---
 
-## 📋 Working Preferences
+## Working Preferences
 
 ### Communication Style
-- **CRITICAL: Low verbosity always**: Keep responses short and concise. Never write long explanations.
-- **Detailed but brief**: Give complete info in minimal words. Cut fluff.
+- **CRITICAL: Low verbosity always** - Keep responses short and concise. Never write long explanations.
 - **Plain English**: Short, casual sentences. No jargon.
 - **Be direct**: Tell the truth. Admit when you don't know. Suggest solutions.
 - **Challenge when needed**: Don't just agree. Push back if something's wrong.
 
 ### Before You Start
-- **Check PROJECT_CONTEXT.md first** before searching files
-- **Check if files exist** before creating new ones
-- **Read recent commits** to understand what changed
+1. **Read `PROJECT.md`** - product spec, architecture, key files
+2. **Check `PROJECT_CONTEXT.md`** - recent changes log
+3. **Check recent commits** - what changed since last update
+4. **Refer to docs**: `DESIGN_SYSTEM.md`, `/docs/RELEASE-NOTES-*.md`, `/docs/CHANGELOG-*.md`
 
 ### Writing Style
 - **UI/User-facing copy**: Never use em dash (—). Use hyphen (-) or rewrite.
 - **Code comments**: Clear and short
-- **Console messages**: Clear for debugging
 - **Error messages**: Clear for users
-- **Agent prompts**: Single lead sentence → short bullets (easy to scan/update)
+- **Agent prompts**: Single lead sentence → short bullets
 
 ### Build & Deploy
-- **Don't auto-run builds** after fixes (unless big refactor)
 - **Always use `pnpm`** not `npm`
+- **Don't auto-run builds** after fixes (unless big refactor)
 
 ### UI Priorities
-Always prioritize clarity and usability over aesthetics.
+Clarity and usability over aesthetics.
 
 ---
 
-## 📋 Context & Workflow
+## Code Quality
 
-### Always Start Here
-1. **Read `PROJECT_CONTEXT.md` first**: Current project state, architecture, key files
-2. **Check recent commits**: What changed since last update
-3. **Refer to docs**: `DESIGN_SYSTEM.md`, `/docs/RELEASE-NOTES-*.md`, `/docs/CHANGELOG-*.md`
-
-### Project Overview
-Generate professional brand voice and style guides using AI in under 5 minutes.
-
-- Input: Website URL or brand description
-- Output: Voice traits, writing rules, examples
-- Tech: Next.js 15, React 19, TypeScript, Tailwind, Supabase, Stripe, OpenAI, Firecrawl
-
----
-
-## 🎯 Key Principles
-
-### Code Quality
-- Use TypeScript strictly (explicit types over `any`)
+- TypeScript strictly - explicit types over `any`
 - Handle errors gracefully with clear user messages
 - Run `pnpm test` before committing
 - Update tests when changing logic
 - Never commit API keys
-- Sanitize user inputs
-- Validate on server side
+- Sanitize user inputs, validate server-side
 
-### Architecture
+---
+
+## Architecture Principles
+
 - Prefer RSC (React Server Components) for data fetching
-- Keep API routes thin (business logic in `/lib`)
+- Keep API routes thin - business logic in `/lib`
 - Supabase is source of truth (localStorage only for creation flow)
-- Use tokens from `lib/style-guide-styles.ts`
+- Use tokens from `lib/style-guide-styles.ts` for typography
 - Update both code and `DESIGN_SYSTEM.md` when changing styles
 
-### Design System
-- Single source: `lib/style-guide-styles.ts` for typography
-- Fonts: Playfair Display (headings), Geist Sans (body)
-- Use Tailwind classes for spacing
-- Document new patterns in `DESIGN_SYSTEM.md`
-
 ---
 
-## 🔍 Token Usage Tracking
+## File Organization
 
-### Monitor Usage
-- Run `npx ccusage@latest` to see daily token consumption
-- Dollar figures show a la carte API pricing (not actual subscription cost)
-
-### When Closing GitHub Issues
-Track token usage for each feature:
-
-1. Run `npx ccusage@latest`
-2. Add comment to issue:
-   ```markdown
-   ## Token Usage Summary
-   **Feature:** [Name]
-   **Date Range:** [Dates]
-   **Total Tokens:** [Amount]
-   **Estimated Cost (a la carte):** $[Amount]
-   ```
-3. Close issue
-
-**Example:**
-```markdown
-## Token Usage Summary
-**Feature:** PDF Export with Puppeteer
-**Date Range:** 2026-02-10 - 2026-02-11
-**Total Tokens:** 127,450
-**Estimated Cost (a la carte):** $3.82
-```
-
----
-
-## 🧪 Testing & Scripts
-
-### Before Committing
-```bash
-# Run tests
-pnpm test
-
-# Test style guide generation
-node scripts/test-real-website.mjs https://example.com
-
-# Generate preview PDF
-node scripts/generate-preview-pdf.mjs
-```
-
-### Token Usage Monitoring
-```bash
-# Check daily token consumption
-npx ccusage@latest
-
-# Use this when closing GitHub issues to log token expenditure
-```
-
----
-
-## 📁 File Organization
-
-### When Adding New Features
-- **API Routes**: `/app/api/[feature]/route.ts`
-- **Business Logic**: `/lib/[feature].ts`
-- **Components**: `/components/[feature]/` or `/components/[FeatureName].tsx`
-- **Types**: Define in same file or `/types/[feature].ts` if shared
-- **Tests**: Co-locate with implementation (e.g., `lib/feature.test.ts`)
+| Type | Location |
+|------|----------|
+| API Routes | `/app/api/[feature]/route.ts` |
+| Business Logic | `/lib/[feature].ts` |
+| Components | `/components/[FeatureName].tsx` |
+| Types | same file, or `/types/[feature].ts` if shared |
+| Tests | co-located with implementation |
 
 ### Documentation Updates
-- **Architecture Changes**: Update `PROJECT_CONTEXT.md`
-- **Design Changes**: Update `DESIGN_SYSTEM.md` + `lib/style-guide-styles.ts`
-- **New Features**: Add to `/docs/RELEASE-NOTES-[YYYY-MM].md`
-- **Breaking Changes**: Document in `/docs/CHANGELOG-[YYYY-MM-DD].md`
+- **Architecture changes**: Update `PROJECT_CONTEXT.md`
+- **Design changes**: Update `DESIGN_SYSTEM.md` + `lib/style-guide-styles.ts`
+- **New features**: Add to `/docs/RELEASE-NOTES-[YYYY-MM].md`
+- **Breaking changes**: Document in `/docs/CHANGELOG-[YYYY-MM-DD].md`
 
 ---
 
-## 🚀 Deployment & Environment
+## Security
 
-### Environment Variables
-Required for full functionality:
-- `OPENAI_API_KEY`: OpenAI API
-- `FIRECRAWL_API_KEY`: Firecrawl (optional, falls back to Cheerio)
-- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Supabase
-- `SUPABASE_SERVICE_ROLE_KEY`: Supabase admin
-- `STRIPE_SECRET_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`: Stripe
-- `STRIPE_WEBHOOK_SECRET`: Stripe webhooks
-- `LANGSMITH_API_KEY`, `LANGSMITH_TRACING`, `LANGSMITH_PROJECT`: LangSmith observability (optional, see `/docs/LANGSMITH-SETUP.md`)
-
-### Deployment
-- **Platform**: Vercel
-- **Database**: Supabase (hosted)
-- **Payments**: Stripe
-- **CDN**: Vercel Edge Network
+1. Never commit secrets - use `.env.local` (gitignored)
+2. Server-side validation for all user inputs
+3. Escape HTML, sanitize markdown outputs
+4. Rate limit API routes (especially `/api/extract-website`)
+5. Always verify `userId` from Supabase before DB operations
 
 ---
 
-## 🔒 Security Best Practices
+## Commit Conventions
 
-1. **Never commit secrets**: Use `.env` and `.env.local` (both gitignored)
-2. **Validate inputs**: Server-side validation for all user inputs
-3. **Sanitize outputs**: Escape HTML, sanitize markdown
-4. **Rate limiting**: API routes should have rate limits (especially `/api/extract-website`)
-5. **CORS**: API routes should validate origin
-6. **Auth checks**: Always verify `userId` from Supabase before DB operations
-
----
-
-## 📝 Commit Conventions
-
-### Commit Messages
-Use conventional commit format:
 ```
 type(scope): subject
 
@@ -193,86 +95,32 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 
 **Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`
 
-**Example:**
+---
+
+## Token Usage Tracking
+
+Run `npx ccusage@latest` to see daily consumption.
+
+When closing GitHub issues, add a comment:
+```markdown
+## Token Usage Summary
+**Feature:** [Name]
+**Date Range:** [Dates]
+**Total Tokens:** [Amount]
+**Estimated Cost (a la carte):** $[Amount]
 ```
-feat(pdf-export): add Puppeteer primary with html2pdf fallback
-
-- Server-side Puppeteer export at /api/export-pdf
-- Client-side html2pdf.js fallback if API fails
-- Exclude locked sections from PDF for free users
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-```
 
 ---
 
-## 🎨 Style Guide Generation Logic
-
-### Key Flows
-1. **Preview Flow** (Free users):
-   - User enters URL/description → `/api/extract-website` (Firecrawl/Cheerio)
-   - Generate preview sections (About, Audience, Voice, Guidelines)
-   - Store in localStorage, redirect to `/guide`
-   - Show gradient fade → locked sections → upgrade CTA
-
-2. **Full Guide Flow** (Paid users):
-   - After payment → generate full guide
-   - **Merge mode**: If preview exists, preserve it, only generate locked sections
-   - Save to DB with `guideId`
-   - Redirect to `/guide?guideId=X`
-
-3. **Edit Flow** (Paid users):
-   - Load from DB by `guideId`
-   - Auto-save on edit (2s debounce)
-   - Switch between edit/preview modes
-
-### Generation Prompts
-- **Extraction**: `lib/prompts/extraction-prompt.ts` (extract brand info from website)
-- **Guide Generation**: `lib/openai.ts` (generate traits, rules, examples)
-- **Template**: `templates/style_guide_template.md` (base structure)
-
----
-
-## 🐛 Debugging Tips
-
-### Common Issues
-1. **Auth errors**: Check Supabase URL/keys, verify RLS policies
-2. **PDF export fails**: Check Puppeteer Chromium binary, fallback to html2pdf
-3. **Firecrawl timeout**: Increase timeout or fallback to Cheerio
-4. **Rate limits**: OpenAI API rate limits → queue requests or show error
-
-### Logging
-- **Server**: Use `console.log` in API routes (visible in Vercel logs)
-- **Client**: Use browser console
-- **Database**: Check Supabase logs for RLS policy violations
-
----
-
-## 📚 Additional Resources
-
-- **Design System**: `DESIGN_SYSTEM.md`
-- **Project Context**: `PROJECT_CONTEXT.md`
-- **Release Notes**: `/docs/RELEASE-NOTES-2026-02.md`
-- **Changelog**: `/docs/CHANGELOG-2025-02-09.md`
-- **Stripe Setup**: `/docs/STRIPE-RESTRICTED-KEY-SETUP.md`
-- **LangSmith Setup**: `/docs/LANGSMITH-SETUP.md` (AI observability)
-
----
-
-## 🎯 Quick Reference
+## Quick Reference
 
 | Task | Command |
 |------|---------|
 | Start dev server | `pnpm dev` |
 | Run tests | `pnpm test` |
-| Build for production | `pnpm build` |
-| Test guide generation | `node scripts/test-real-website.mjs <url>` |
+| Build | `pnpm build` |
 | Check token usage | `npx ccusage@latest` |
-| Generate preview PDF | `node scripts/generate-preview-pdf.mjs` |
 
 ---
 
-**Last Updated:** 2026-02-12
-**Maintained By:** Development team + Claude Code
-
-When in doubt, read `PROJECT_CONTEXT.md` first, then refer back to this file for workflows and best practices.
+**Last Updated:** 2026-02-18

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ For product details, architecture, and flows see **`PROJECT.md`**.
 - **CRITICAL: Low verbosity always** - Keep responses short and concise. Never write long explanations.
 - **Plain English**: Short, casual sentences. No jargon.
 - **Be direct**: Tell the truth. Admit when you don't know. Suggest solutions.
-- **Challenge when needed**: Don't just agree. Push back if something's wrong.
+- **Be critical**: Evaluate approaches honestly. Push back when an implementation is weak, a flow is confusing, or a shortcut will cause problems later. Don't say what the user wants to hear.
 
 ### Before You Start
 1. **Read `PROJECT.md`** - product spec, architecture, key files
@@ -20,9 +20,8 @@ For product details, architecture, and flows see **`PROJECT.md`**.
 4. **Refer to docs**: `DESIGN_SYSTEM.md`, `/docs/RELEASE-NOTES-*.md`, `/docs/CHANGELOG-*.md`
 
 ### Clarifying Before Starting
-- If a task is ambiguous, ask 1-2 targeted clarifying questions **before** writing any code
-- Identify the success criteria upfront. If not given, state your assumed "Done when:" and proceed
-- Frame your understanding of the task back to the user in one sentence before starting complex work
+- Only ask clarifying questions when there's **genuine high uncertainty** that would cause you to build the wrong thing - don't ask about details you can figure out
+- If not given success criteria, state your assumed "Done when:" in one sentence and proceed
 - Never ask clarifying questions mid-task - make reasonable decisions and keep going
 
 ### Writing Style
@@ -55,10 +54,10 @@ Clarity and usability over aesthetics.
 | Tool | How to use | Notes |
 |------|-----------|-------|
 | `pnpm` | `pnpm <cmd>` | Always use instead of npm |
-| `supabase` | `npx supabase <cmd>` | Supabase CLI (not globally installed) |
-| `vercel` | Not available | Use Vercel dashboard or env config |
+| `supabase` | `npx supabase <cmd>` | Not globally installed |
+| `vercel` | `vercel <cmd>` | Installed globally |
+| `gh` | `gh <cmd>` | Installed globally |
 | `stripe` | Not available | Use API directly or Stripe dashboard |
-| `gh` | Not available | Use GitHub web UI |
 
 For Supabase schema/data operations: `npx supabase db ...` or query via the Supabase MCP server if configured.
 
@@ -72,6 +71,8 @@ For Supabase schema/data operations: `npx supabase db ...` or query via the Supa
 - Update tests when changing logic
 - Never commit API keys
 - Sanitize user inputs, validate server-side
+- **Always leave comments** when writing or refactoring code - explain the why, not the what
+- Use documented APIs and official SDKs - don't roll your own when a library exists
 
 ---
 
@@ -82,6 +83,40 @@ For Supabase schema/data operations: `npx supabase db ...` or query via the Supa
 - Supabase is source of truth (localStorage only for creation flow)
 - Use tokens from `lib/style-guide-styles.ts` for typography
 - Update both code and `DESIGN_SYSTEM.md` when changing styles
+
+---
+
+## Best Practices
+
+Apply these standards by default - don't wait to be asked:
+
+**UX & Product**
+- User flows should be obvious - if a user has to think, simplify
+- Information architecture: group related things, separate unrelated things, hierarchy first
+- Error states, empty states, and loading states are part of the feature - not afterthoughts
+- Microcopy matters: labels, placeholders, CTAs, and tooltips should be specific and action-oriented
+- Confirm destructive actions; use optimistic UI for non-destructive ones
+
+**UI & Responsive Design**
+- Mobile-first. Test every layout at 375px, 768px, and 1280px
+- Touch targets minimum 44px. Don't hide important actions on mobile
+- Don't use fixed pixel widths for containers - use `max-w-*` with full width defaults
+
+**Backend & Data**
+- Validate at the boundary (API route), not just the client
+- Keep DB queries out of components - go through `/lib` or API routes
+- Never expose internal error details to the client
+- Use Supabase RLS as the last line of defence, not the only one
+
+**Auth & Security**
+- Verify `userId` from Supabase session before any DB write
+- Don't trust client-sent `userId` - always derive from session server-side
+- Middleware handles route protection; individual routes handle data protection
+
+**APIs & Integrations**
+- Use official SDKs (Stripe.js, Supabase client) - don't hand-roll API calls
+- Handle webhook events idempotently - assume they can arrive more than once
+- Log enough context to debug production issues without logging PII
 
 ---
 
@@ -115,15 +150,21 @@ For Supabase schema/data operations: `npx supabase db ...` or query via the Supa
 
 ## Commit Conventions
 
+Commits are a permanent record - write them for someone reading the history in 6 months.
+
 ```
 type(scope): subject
 
-body (optional)
+- What changed and why (not just what)
+- Note any trade-offs or decisions made
+- Reference issues or PRs if relevant
 
 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 ```
 
 **Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`
+
+Always push to GitHub after completing a feature or fix so work is never lost locally.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ For product details, architecture, and flows see **`PROJECT.md`**.
 3. **Check recent commits** - what changed since last update
 4. **Refer to docs**: `DESIGN_SYSTEM.md`, `/docs/RELEASE-NOTES-*.md`, `/docs/CHANGELOG-*.md`
 
+### Clarifying Before Starting
+- If a task is ambiguous, ask 1-2 targeted clarifying questions **before** writing any code
+- Identify the success criteria upfront. If not given, state your assumed "Done when:" and proceed
+- Frame your understanding of the task back to the user in one sentence before starting complex work
+- Never ask clarifying questions mid-task - make reasonable decisions and keep going
+
 ### Writing Style
 - **UI/User-facing copy**: Never use em dash (—). Use hyphen (-) or rewrite.
 - **Code comments**: Clear and short
@@ -31,6 +37,30 @@ For product details, architecture, and flows see **`PROJECT.md`**.
 
 ### UI Priorities
 Clarity and usability over aesthetics.
+
+---
+
+## Agentic Working Style
+
+- **Don't stop mid-task** to ask permission or confirm small decisions - make reasonable choices and keep going
+- **Frame the full feature**, not the first step. When given a feature request, plan, scaffold, and connect all files needed to complete it end-to-end
+- **Use success criteria as your finish line**: if the task includes "Done when:", run until every criterion is met before responding
+- **If genuinely blocked** (missing secret, broken auth, external dependency) - state exactly what you'd do next, why you can't proceed, and what the user needs to do. Don't just hand the task back
+- **Complete, then report** - deliver the finished thing with a short summary, not a running commentary
+
+---
+
+## Available CLIs & Tools
+
+| Tool | How to use | Notes |
+|------|-----------|-------|
+| `pnpm` | `pnpm <cmd>` | Always use instead of npm |
+| `supabase` | `npx supabase <cmd>` | Supabase CLI (not globally installed) |
+| `vercel` | Not available | Use Vercel dashboard or env config |
+| `stripe` | Not available | Use API directly or Stripe dashboard |
+| `gh` | Not available | Use GitHub web UI |
+
+For Supabase schema/data operations: `npx supabase db ...` or query via the Supabase MCP server if configured.
 
 ---
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,220 @@
+# Tone of Voice App - Product Spec
+
+**Last Updated:** 2026-02-18
+**Domain:** toneofvoice.app (previously aistyleguide.com)
+**Stack:** Next.js 15, React 19, TypeScript, Tailwind, Supabase, Stripe, OpenAI, Firecrawl
+
+---
+
+## What This Product Does
+
+AI-powered SaaS that generates professional tone of voice guides in under 5 minutes.
+
+**Input:** Website URL or brand description
+**Output:** A comprehensive guide covering:
+- 3 brand voice traits (definition, do's, don'ts)
+- 25 writing rules (tone, grammar, formatting)
+- 10 brand terms and phrases for consistent vocabulary
+- 5 before/after examples showing voice applied to real content
+- Export formats: PDF (Puppeteer + html2pdf fallback), Word-compatible HTML, Markdown
+
+---
+
+## Subscription Tiers
+
+| Tier | Guides | Access |
+|------|--------|--------|
+| Free Preview | 1 | Preview sections only (locked sections behind paywall) |
+| Starter | 10/month | Full access, all export formats |
+| Pro | 2 | Full access, all export formats |
+| Agency (formerly Team) | Unlimited | Full access, all features + roadmap |
+
+Guide limits enforced via `/api/user-guide-limit` and Supabase row-level security.
+
+---
+
+## Key User Flows
+
+### 1. Preview Flow (Free)
+1. User enters URL or description at `/brand-details`
+2. `/api/extract-website` scrapes site (Firecrawl primary, Cheerio fallback) → OpenAI extracts brand info
+3. AI generates preview sections: About, Audience, Voice, Guidelines
+4. Stored in localStorage, redirected to `/guide`
+5. Gradient fade → locked sections → upgrade CTA
+
+### 2. Full Guide Flow (Paid)
+1. After Stripe payment → generate full guide
+2. **Merge mode**: If preview exists, preserve it, only generate locked sections
+3. Save to Supabase DB with `guideId`
+4. Redirect to `/guide?guideId=X`
+
+### 3. Edit Flow (Paid)
+1. Load guide from DB by `guideId`
+2. Plate.js editor with full formatting toolkit + AI (Cmd+J)
+3. Auto-save on edit (2s debounce)
+4. Switch between edit/preview modes
+
+---
+
+## Architecture
+
+### Storage Strategy
+- **localStorage**: Creation flow only (brand details, preview content)
+- **Supabase DB**: Source of truth once guide has `guideId`
+- **Auto-save**: 2s debounce on edits (authenticated + has guideId)
+
+### Website Extraction
+- Firecrawl scrapes page to markdown → OpenAI extracts brand info
+- If homepage thin (<2500 chars), maps and scrapes 2-3 key subpages
+- Fallback: Cheerio when `FIRECRAWL_API_KEY` not set
+- Both URL and description routes use same OpenAI model/prompt for consistency
+
+### PDF Export
+1. **Primary**: POST to `/api/export-pdf` (Puppeteer + Chromium, server-side)
+2. **Fallback**: Client-side html2pdf.js if API fails
+3. Locked sections excluded from PDF for free users
+
+### AI/LLM
+- Model: gpt-5.2 with `reasoning_effort: "none"` for extraction (speed/cost)
+- Generation prompts: `lib/openai.ts`
+- Extraction prompt: `lib/prompts/extraction-prompt.ts`
+- Template: `templates/style_guide_template.md`
+- LangSmith for trace monitoring (optional, see `/docs/LANGSMITH-SETUP.md`)
+
+---
+
+## Guide Content Structure
+
+### Audience Section
+- **Overview**: 1 sentence, who we write for (demographic/context, not "people who rely on us")
+- **Primary**: 2 paragraphs, 2 sentences each (who + context, then goals/motivations/anxieties)
+- **Secondary**: 1 paragraph, 2 sentences, brief only
+- No writing advice in this section. Works for B2B, B2C, any brand.
+- Headings: `### Audience (Overview)`, `### Primary Audience`, `### Secondary Audience`
+
+### Word Lists
+Order: Preferred Terms → Spelling and Usage → Avoid Terms
+Format: Two-column tables (Use | Instead of) for Preferred Terms and Spelling/Usage
+
+### Content Rules
+- No em dashes anywhere in generated content or UI copy - use hyphens or rewrite
+- Brand description: 80-120 words, 2-3 paragraphs, outcome-focused, no buzzwords
+
+---
+
+## Key Directories & Files
+
+### `/app`
+- `/api/extract-website/route.ts` - website scraping + AI extraction
+- `/api/export-pdf/route.ts` - Puppeteer PDF generation
+- `/api/user-guide-limit/route.ts` - guide limit checking
+- `/api/webhook/route.ts` - Stripe webhooks
+- `/api/ai/command/route.ts` - Plate.js AI (Cmd+J, streaming, auth-gated)
+- `/brand-details` - input form
+- `/guide` - unified guide view/edit (preview + full-access)
+- `/dashboard` - guide list, billing
+- `/payment` - Stripe checkout
+- `/auth`, `/sign-in`, `/sign-up` - Supabase auth
+
+### `/components`
+- `StyleGuideView.tsx` - main guide component (edit/preview modes)
+- `StyleGuideEditor.tsx` - Plate.js editor
+- `MarkdownRenderer.tsx` - polished preview renderer
+- `StyleGuideCover.tsx` - cover page (brand name, date, metadata)
+- `ContentGate.tsx` - paywall (fade + locked headers + CTA)
+- `UpgradeNudgeModal.tsx` - guide limit nudge modal
+- `UserMenu.tsx` - auth menu (sign out, billing)
+- `Footer.tsx` - reusable footer
+
+### `/lib`
+- `openai.ts` - OpenAI API calls and generation prompts
+- `template-processor.ts` - template rendering, merge logic
+- `firecrawl-site-scraper.ts` - Firecrawl integration, smart scraping
+- `content-parser.ts` - parses guide sections
+- `style-guide-styles.ts` - typography tokens (`PREVIEW_*`, `EDITOR_*`)
+- `api-utils.ts` - error mapping (`getUserFriendlyError`, `isAbortError`); error codes: `REQUEST_ABORTED`, `SESSION_EXPIRED`, `INVALID_RESPONSE`, `STORAGE_CORRUPT`
+- `supabase-*.ts` - Supabase client utilities
+
+### `/docs`
+- `RELEASE-NOTES-2026-02.md` - February 2026 release notes
+- `REBRAND-TONEOFVOICE.md` - rebrand plan (aistyleguide.com → toneofvoice.app)
+- `STRIPE-RESTRICTED-KEY-SETUP.md` - Stripe restricted key setup
+- `LANGSMITH-SETUP.md` - AI observability setup
+
+### Other
+- `DESIGN_SYSTEM.md` - fonts, colors, spacing, components
+- `templates/style_guide_template.md` - base template for guide generation
+- `PROJECT_CONTEXT.md` - recent changes log (update after major changes)
+
+---
+
+## Design System
+
+- **Typography source of truth**: `lib/style-guide-styles.ts`
+- **Fonts**: Playfair Display (serif headings), Geist Sans (body)
+- **Tokens**: `PREVIEW_*` for read-only mode, `EDITOR_*` for edit mode
+- **Spacing**: Tailwind classes
+- **Docs**: `DESIGN_SYSTEM.md`
+
+---
+
+## Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `OPENAI_API_KEY` | Yes | OpenAI API |
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase auth |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase auth |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase admin ops |
+| `STRIPE_SECRET_KEY` | Yes | Stripe payments |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Yes | Stripe client |
+| `STRIPE_WEBHOOK_SECRET` | Yes | Stripe webhooks |
+| `FIRECRAWL_API_KEY` | Optional | Falls back to Cheerio |
+| `LANGSMITH_API_KEY` | Optional | AI observability |
+| `LANGSMITH_TRACING` | Optional | AI observability |
+| `LANGSMITH_PROJECT` | Optional | AI observability |
+
+---
+
+## Deployment
+
+- **Platform**: Vercel
+- **Database**: Supabase (hosted)
+- **Payments**: Stripe
+- **Dev server**: `pnpm dev` (port 3002)
+
+---
+
+## Debugging
+
+| Issue | Fix |
+|-------|-----|
+| Auth errors | Check Supabase URL/keys, verify RLS policies |
+| PDF export fails | Check Puppeteer Chromium binary, fallback to html2pdf |
+| Firecrawl timeout | Increase timeout or fallback to Cheerio |
+| Rate limits | OpenAI rate limits - queue requests or show error |
+
+- **Server logs**: `console.log` in API routes (Vercel logs)
+- **DB**: Check Supabase logs for RLS policy violations
+
+---
+
+## Testing & Scripts
+
+```bash
+pnpm test                                              # Run Vitest tests
+pnpm test:watch                                        # Watch mode
+node scripts/test-audience-prompt.mjs                 # Test audience prompt (Tesco, Stripe, description)
+node scripts/test-audience-prompt.mjs --url <url>     # Custom URL
+curl -X POST http://localhost:3002/api/extract-website \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://stripe.com"}'                   # Test extraction API
+npx ccusage@latest                                    # Check Claude Code token usage
+```
+
+---
+
+## Known Issues
+
+- `README.md` is outdated (references deprecated "core/complete" guide types)
+- Old routes `/preview` and `/full-access` redirect to `/guide` for backward compat

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,6 +1,6 @@
 # Tone of Voice App - Project Context
 
-**Last Updated:** 2026-02-16
+**Last Updated:** 2026-02-18
 **Project:** AI-powered tone of voice guide generator
 **Stack:** Next.js 15, React 19, TypeScript, Tailwind, Supabase, Stripe, OpenAI, Firecrawl
 
@@ -19,6 +19,21 @@ Tone of Voice App is a SaaS platform that generates professional tone of voice g
 ---
 
 ## 📊 Recent Major Changes (Last 2 Weeks)
+
+### Rebrand Polish + AI Fixes (Feb 16-18, 2026)
+- **Terminology**: All user-facing copy switched to "Tone of Voice" (removed "style guide" references throughout)
+- **Wordmark**: `public/wordmark.svg` + `public/wordmark.png` added; `Logo.tsx` now renders wordmark in nav; nav links centered with absolute positioning on desktop
+- **SEO**: `public/robots.txt` and `public/sitemap.xml` added; enhanced metadata (keywords, secure URLs) in `app/layout.tsx`
+- **Style Rules prompt** (`lib/openai.ts`): Encourages varied sentence structures - "Use contractions to sound warm" vs "Multiple exclamation marks feel jarring" rather than formulaic patterns
+- **AI Cmd+J** (`app/api/ai/command/route.ts`, `components/ui/ai-menu.tsx`): Fixed custom prompt submission (now includes mode, toolName, template); minimality constraint added to prevent over-editing; model upgraded to `gpt-5-mini`
+- **Auth/checkout**: Generic error messages for sign-up and checkout; "Get Pro/Agency" copy; lock icons added to `GuideSidebar`; Vercel env var logging added
+- **Cover**: Heading container widened (`max-w-3xl` → `max-w-5xl`) to prevent unnecessary wrapping
+- **Audience Overview**: Label simplified from "Audience (Overview)" to "Overview"
+- **`normalizeMarkdownContent()`** added in `lib/template-processor.ts` for audience section whitespace handling
+- **New test scripts**: `scripts/test-style-rules.mjs`, `scripts/test-style-rules-detailed.mjs` - run against guide content to validate rule quality and variety
+- **`scripts/test-audience-prompt.mjs`**: Expanded with `--url` and `--desc` flags, better output formatting
+- **Interstitial**: Removed redundant paragraph + blue banner; consolidated loading state messaging; banner copy generalized to "Generate full guidelines"
+- **"How to Use" section**: Bold headings converted to `###` markdown headings with proper spacing
 
 ### Audience Section & Error Handling (Feb 16, 2026)
 - **Audience prompt overhaul** (`lib/openai.ts`): New prompt drives content-team-friendly output


### PR DESCRIPTION
- Add PROJECT.md with full product spec (product overview, flows,
  architecture, files, env vars, tiers, debugging, scripts)
- Remove product-specific sections from CLAUDE.md (now just working
  preferences, code quality, conventions)
- CLAUDE.md points to PROJECT.md as primary product reference

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only restructuring with no runtime code changes; low risk beyond potential documentation drift/inaccuracy.
> 
> **Overview**
> Adds a new canonical product/architecture reference (`PROJECT.md`) that documents the app’s key flows, tiering, architecture decisions, important directories/routes, env vars, debugging, and test/scripts.
> 
> Refactors `CLAUDE.md` to remove product-specific walkthroughs and instead focus on durable working conventions (communication style, agent workflow, code quality, security, tooling, file organization), explicitly pointing readers to `PROJECT.md` for product details; updates `PROJECT_CONTEXT.md` with a new Feb 16–18 changelog entry and timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2140855acd670b95d4f9ed66c50d74563ab10316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->