### PR TITLE
fix(hero): update H1 to 'Create your tone of voice guidelines in minu…

### DIFF
--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -47,7 +47,7 @@ export default function HeroSection() {
             AI-Powered Tone of Voice Guidelines
           </div>
           <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl mb-4">
-            Get ChatGPT to <em>finally</em> sound like you
+            Create your tone of voice guidelines in minutes
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mb-8 hero-lead">
             Stop asking AI to &quot;make it sound good.&quot; Create high-quality, professional{" "}


### PR DESCRIPTION
…tes'

Replaces the previous headline to better communicate the core value proposition - helping users create guidelines, not just sound like themselves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change to the marketing hero section with no logic, data, or security impact.
> 
> **Overview**
> Updates the landing page hero headline in `components/landing/hero-section.tsx`, replacing “Get ChatGPT to finally sound like you” with “Create your tone of voice guidelines in minutes” to better reflect the product’s value proposition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ea6e6cfc852df548894dc15d15651ab45367a80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->