### PR TITLE
fix(landing): rename AISG to TOV App in comparison table

### DIFF
--- a/components/landing/comparison-section.tsx
+++ b/components/landing/comparison-section.tsx
@@ -48,7 +48,7 @@ function AisgLabel() {
           <div className="bg-indigo-600"></div>
         </div>
       </div>
-      <span>AISG</span>
+      <span>TOV App</span>
     </div>
   )
 }
@@ -64,7 +64,7 @@ function MobileAisgLabel() {
           <div className="bg-indigo-600"></div>
         </div>
       </div>
-      <span>AISG</span>
+      <span>TOV App</span>
     </div>
   )
 }


### PR DESCRIPTION
Updated both desktop and mobile labels in the comparison section header.

Co-Authored-By: Claude <noreply@anthropic.com>