### PR TITLE
Claude/diagnose critical issue w y2y j

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -247,6 +247,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing stripe-signature header" }, { status: 400 })
   }
 
+  if (!STRIPE_WEBHOOK_SECRET) {
+    console.error(`[webhook] STRIPE_WEBHOOK_SECRET not configured (mode=${mode})`)
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 })
+  }
+
   try {
     const stripe = getStripe()
     // Verify webhook signature using raw buffer
@@ -306,10 +311,6 @@ export async function POST(request: Request) {
       console.error("Could not parse webhook payload:", parseErr)
     }
     
-    return NextResponse.json({ 
-      error: "Webhook handler failed", 
-      message: err.message,
-      url: normalizedUrl
-    }, { status: 400 })
+    return NextResponse.json({ error: "Webhook handler failed" }, { status: 400 })
   }
 } 

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,6 +22,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api/webhook|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,3 +2,6 @@
 
 - Create this file at session start when missing.
 - Keep cloud environment changes minimal and verifiable.
+- Always exclude webhook routes from auth middleware. Stripe webhooks have no session cookies - auth middleware just adds latency and timeout risk.
+- Guard env vars with early returns and clear log messages before passing them to SDK methods. Passing `undefined` to typed SDK functions produces cryptic errors.
+- Never leak internal error messages (err.message, stack traces, URLs) in API responses. Log them server-side, return generic messages to callers.


### PR DESCRIPTION
## Summary
- Exclude `/api/webhook` from Supabase auth middleware - unnecessary HTTP roundtrip causing latency/timeouts
- Add early guard for missing `STRIPE_WEBHOOK_SECRET` env var
- Remove internal error message leak from webhook error response

## Test plan
- [ ] Deploy and check webhook logs for successful signature verification
- [ ] Trigger test event from Stripe dashboard, confirm 200
- [ ] Verify `STRIPE_WEBHOOK_SECRET` is set in Vercel env vars
